### PR TITLE
Fixes to bef2c & befprof

### DIFF
--- a/src/befprof.c
+++ b/src/befprof.c
@@ -557,14 +557,14 @@ int main (argc, argv)
       y += dy;
       if (x < 0)
       {
-        x = LINEWIDTH - 1;
+        x += LINEWIDTH;
       } else
       {
         x = x % LINEWIDTH;
       }
       if (y < 0)
       {
-        y = PAGEHEIGHT - 1;
+        y += PAGEHEIGHT;
       } else
       {
         y = y % PAGEHEIGHT;


### PR DESCRIPTION
Double free due to double fclose
Trampoline at leftmost/topmost edges
Don't print \0 into sourcecode
Use %% instead of %c with '%' being passed in
Avoid freeing fo/fi on failure to open

_I stopped into IRC a few years ago & said hello. Well, hello again. Been getting back into Befunge by writing a program that JITs Befunge code into Python bytecode (using the Python stack itself as the Befunge stack, wee segfaulting CPython's not-memory-safe bytecode)_
